### PR TITLE
fix: explicitly pass process.env

### DIFF
--- a/src/createExecute.ts
+++ b/src/createExecute.ts
@@ -37,6 +37,7 @@ export const createExecute =
                 args,
                 {
                     cwd: runFrom ? path.join(base, runFrom) : path.join(base),
+                    env: process.env,
                 }
             );
 


### PR DESCRIPTION
Closes #8 

Pass `process.env` explicitly since jest tries to sandbox it which means that it doesn't work as one might expect.