### PR TITLE
fix: Command spaces parsing

### DIFF
--- a/src/createExecute.ts
+++ b/src/createExecute.ts
@@ -2,6 +2,7 @@ import { Output } from './Output';
 import { ChildProcessWithoutNullStreams, spawn } from 'child_process';
 import { homedir } from 'os';
 import path from 'path';
+import { parseCommand } from './utils';
 
 export type ExitCode = 0 | 1;
 export type ExecResult = { code: ExitCode; stdout: string[]; stderr: string[] };
@@ -27,8 +28,7 @@ export const createExecute =
                 '': '', // you might not see it, but there is a special ESC symbol
             };
 
-            const args = command
-                .split(' ')
+            const args = parseCommand(command)
                 .map((arg) =>
                     arg.includes('./') ? path.join(process.cwd(), arg) : arg
                 );

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,13 +1,32 @@
-import { ChildProcessWithoutNullStreams } from 'child_process';
+import {ChildProcessWithoutNullStreams} from 'child_process';
 
 export const checkRunningProcess = (currentProcessRef: {
-    current: ChildProcessWithoutNullStreams | null;
+  current: ChildProcessWithoutNullStreams | null;
 }): currentProcessRef is { current: ChildProcessWithoutNullStreams } => {
-    if (!currentProcessRef.current) {
-        throw new Error(
-            'No process is running. Start it with `execute`, or the process has already finished.'
-        );
-    }
+  if (!currentProcessRef.current) {
+    throw new Error(
+      'No process is running. Start it with `execute`, or the process has already finished.'
+    );
+  }
 
-    return true;
+  return true;
+};
+
+const SPACES_REGEXP = / +/g;
+
+export const parseCommand = (command: string): string[] => {
+  const tokens: string[] = [];
+
+  for (const token of command.trim().split(SPACES_REGEXP)) {
+    // Allow spaces to be escaped by a backslash if not meant as a delimiter
+    const previousToken = tokens[tokens.length - 1];
+    if (previousToken && previousToken.endsWith('\\')) {
+      // Merge previous token with current one
+      tokens[tokens.length - 1] = `${previousToken.slice(0, -1)} ${token}`;
+    } else {
+      tokens.push(token);
+    }
+  }
+
+  return tokens;
 };

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -124,6 +124,21 @@ describe('Tests testing the CLI and so, the testing lib itself', () => {
 
             await cleanup();
         });
+
+        it('should escape spaces when needed', async () => {
+            const { spawn, cleanup } = await prepareEnvironment();
+
+            const { getStdout, waitForFinish } = await spawn(
+              'node',
+              './test/testing-cli-entry.js print "some\\ fancy\\ text"'
+            );
+
+            await waitForFinish()
+
+            expect(getStdout()).toContain('cli:print: "some fancy text"');
+
+            await cleanup();
+        });
     });
 
     describe('command:help', () => {


### PR DESCRIPTION
When running a command like `git commit -m "some fancy commit"` I will be wrongly parsed to an array like this

```
[
    "commit",
    "-m",
    "\"some",
    "fancy",
    "commit\""
]
```

and the command will fail.
This PR adds the possibility to escape those spaces by doing this  `git commit -m "some\\ fancy\\ commit"` so the result of the array will be like 

```
[
    "commit",
    "-m",
    "\"some fancy commit\""
]
```